### PR TITLE
Changing sort to randomize when overall is equal

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,7 +76,7 @@ function CSVReader2() {
 
   useEffect(() => {
     data.sort((a, b) =>
-    a[overall] > b[overall] ? 1 : b[overall] > a[overall] ? -1 : 0
+    a[overall] > b[overall] ? 1 : b[overall] > a[overall] ? -1 : Math.floor(Math.random() * 2) || -1
   );
   setSortedData(data);
   algoritmoGuloso(sortedData);


### PR DESCRIPTION
I have changed the sort function to randomize when players have the same overall so players with same overall will not be grouped in the same order and we are going to have a different order list of players bringing us to have a different division on 3 teams.